### PR TITLE
Perform allocation on Reserve categories when transactions occur on Income categories

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>net.salmonsoft</groupId>
 	<artifactId>cashpiles</artifactId>
-	<version>0.1.2-SNAPSHOT</version>
+	<version>0.1.3-SNAPSHOT</version>
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 	</properties>
@@ -30,7 +30,7 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-assembly-plugin</artifactId>
-				<version>3.0.0</version>
+				<version>3.3.0</version>
 				<configuration>
 					<descriptorRefs>
 						<descriptorRef>jar-with-dependencies</descriptorRef>

--- a/src/main/java/cashpiles/model/Allocation.java
+++ b/src/main/java/cashpiles/model/Allocation.java
@@ -4,7 +4,6 @@ import cashpiles.ledger.CategoryTransactionEntry;
 
 class Allocation extends ModelItem {
 
-	private boolean active = false;
 	private Category category;
 	private CategoryTransactionEntry entry;
 
@@ -13,8 +12,12 @@ class Allocation extends ModelItem {
 		this.entry = entry;
 	}
 
-	boolean active() {
-		return active;
+	Category allocate(Category category) {
+		return category;
+	}
+
+	Category allocate(ReserveCategory category) throws LedgerModelException {
+		return category;
 	}
 
 	Category category() {
@@ -23,12 +26,6 @@ class Allocation extends ModelItem {
 
 	CategoryTransactionEntry entry() {
 		return entry;
-	}
-
-	Allocation makeActive() {
-		var retval = clone();
-		retval.active = true;
-		return retval;
 	}
 
 	@Override

--- a/src/main/java/cashpiles/model/Allocation.java
+++ b/src/main/java/cashpiles/model/Allocation.java
@@ -1,0 +1,39 @@
+package cashpiles.model;
+
+import cashpiles.ledger.CategoryTransactionEntry;
+
+class Allocation extends ModelItem {
+
+	private boolean active = false;
+	private Category category;
+	private CategoryTransactionEntry entry;
+
+	Allocation(Category category, CategoryTransactionEntry entry) {
+		this.category = category;
+		this.entry = entry;
+	}
+
+	boolean active() {
+		return active;
+	}
+
+	Category category() {
+		return category;
+	}
+
+	CategoryTransactionEntry entry() {
+		return entry;
+	}
+
+	Allocation makeActive() {
+		var retval = clone();
+		retval.active = true;
+		return retval;
+	}
+
+	@Override
+	public Allocation clone() {
+		return (Allocation) super.clone();
+	}
+
+}

--- a/src/main/java/cashpiles/model/Category.java
+++ b/src/main/java/cashpiles/model/Category.java
@@ -14,7 +14,7 @@ import cashpiles.util.Lists;
 abstract class Category extends ModelItem implements CategoryView {
 
 	private final String owner;
-	private List<BudgetPeriod> periods = new ArrayList<>();
+	protected List<BudgetPeriod> periods = new ArrayList<>();
 	private final LocalDate startDate;
 	private final DateRange startDates;
 
@@ -67,6 +67,10 @@ abstract class Category extends ModelItem implements CategoryView {
 	@Override
 	abstract public String type();
 
+	Category withAllocation(Allocation allocation) throws LedgerModelException {
+		return this;
+	}
+
 	Category withDate(CategoryTransactionEntry entry) throws LedgerModelException {
 		var retval = clone();
 		if (entry.parent().date().compareTo(retval.periods.get(0).dates().startDate()) < 0) {
@@ -105,14 +109,14 @@ abstract class Category extends ModelItem implements CategoryView {
 		return retval;
 	}
 
-	Category withTransaction(CategoryTransactionEntry entry) throws LedgerModelException {
-		var retval = withDate(entry);
-		var period = Lists.lastOf(retval.periods);
-		retval.periods.remove(retval.periods.size() - 1);
+	Allocation withTransaction(CategoryTransactionEntry entry) throws LedgerModelException {
+		var updated = withDate(entry);
+		var period = Lists.lastOf(updated.periods);
+		updated.periods.remove(updated.periods.size() - 1);
 		period = period.withTransaction(entry);
 		period = allocate(period);
-		retval.periods.add(period);
-		return retval;
+		updated.periods.add(period);
+		return new Allocation(updated, entry);
 	}
 
 }

--- a/src/main/java/cashpiles/model/IncomeAllocation.java
+++ b/src/main/java/cashpiles/model/IncomeAllocation.java
@@ -1,0 +1,16 @@
+package cashpiles.model;
+
+import cashpiles.ledger.CategoryTransactionEntry;
+
+class IncomeAllocation extends Allocation {
+
+	IncomeAllocation(Category category, CategoryTransactionEntry entry) {
+		super(category, entry);
+	}
+
+	@Override
+	Category allocate(ReserveCategory category) throws LedgerModelException {
+		return category.allocate(entry());
+	}
+
+}

--- a/src/main/java/cashpiles/model/IncomeAllocation.java
+++ b/src/main/java/cashpiles/model/IncomeAllocation.java
@@ -9,7 +9,7 @@ class IncomeAllocation extends Allocation {
 	}
 
 	@Override
-	Category allocate(ReserveCategory category) throws LedgerModelException {
+	ReserveCategory allocate(ReserveCategory category) throws LedgerModelException {
 		return category.allocate(entry());
 	}
 

--- a/src/main/java/cashpiles/model/IncomeCategory.java
+++ b/src/main/java/cashpiles/model/IncomeCategory.java
@@ -2,6 +2,7 @@ package cashpiles.model;
 
 import java.time.LocalDate;
 
+import cashpiles.ledger.CategoryTransactionEntry;
 import cashpiles.time.DateRange;
 
 class IncomeCategory extends Category {
@@ -27,6 +28,13 @@ class IncomeCategory extends Category {
 	@Override
 	public String type() {
 		return "Income";
+	}
+
+	@Override
+	public Allocation withTransaction(CategoryTransactionEntry entry) throws LedgerModelException {
+		var retval = super.withTransaction(entry);
+		retval = retval.makeActive();
+		return retval;
 	}
 
 }

--- a/src/main/java/cashpiles/model/IncomeCategory.java
+++ b/src/main/java/cashpiles/model/IncomeCategory.java
@@ -13,10 +13,6 @@ class IncomeCategory extends Category {
 
 	@Override
 	BudgetPeriod allocate(BudgetPeriod period) {
-		// FIXME this needs to trigger each of the reserve categories to allocate based
-		// on the transaction amount -> fortunately we know the transaction amount
-		// because we always zero the balance, so whatever the outstanding balance here
-		// is what we have to base the reserve % on
 		return period.withAllocation(period.activity().negate());
 	}
 
@@ -32,9 +28,8 @@ class IncomeCategory extends Category {
 
 	@Override
 	public Allocation withTransaction(CategoryTransactionEntry entry) throws LedgerModelException {
-		var retval = super.withTransaction(entry);
-		retval = retval.makeActive();
-		return retval;
+		var alloc = super.withTransaction(entry);
+		return new IncomeAllocation(alloc.category(), alloc.entry());
 	}
 
 }

--- a/src/main/java/cashpiles/model/Ledger.java
+++ b/src/main/java/cashpiles/model/Ledger.java
@@ -167,7 +167,7 @@ public class Ledger implements ItemProcessor {
 		var allocation = category.withTransaction(entry);
 		categories.put(entry.category(), allocation.category());
 		for (var c : categories.entrySet()) {
-			c.setValue(c.getValue().withAllocation(allocation));
+			c.setValue(c.getValue().allocate(allocation));
 		}
 		processTracking(entry);
 	}

--- a/src/main/java/cashpiles/model/Ledger.java
+++ b/src/main/java/cashpiles/model/Ledger.java
@@ -4,9 +4,7 @@ import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
 import java.time.LocalDate;
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 import java.util.Optional;
 import java.util.TreeMap;
 
@@ -41,7 +39,6 @@ public class Ledger implements ItemProcessor {
 	private final CategoriesMap categories = new CategoriesMap();
 	private final TreeMap<LocalDate, List<LedgerItem>> items = new TreeMap<>();
 	private final List<ActionListener> listeners = new ArrayList<>();
-	private final Map<String, Amount> owners = new HashMap<>();
 	private Optional<List<LedgerItem>> preDatedItems = Optional.of(new ArrayList<>());
 
 	public void addListener(ActionListener listener) {
@@ -166,8 +163,12 @@ public class Ledger implements ItemProcessor {
 		for (var c : categories.entrySet()) {
 			c.setValue(c.getValue().withDate(entry));
 		}
-		category = category.withTransaction(entry);
-		categories.put(entry.category(), category);
+
+		var allocation = category.withTransaction(entry);
+		categories.put(entry.category(), allocation.category());
+		for (var c : categories.entrySet()) {
+			c.setValue(c.getValue().withAllocation(allocation));
+		}
 		processTracking(entry);
 	}
 
@@ -219,7 +220,7 @@ public class Ledger implements ItemProcessor {
 			throw LedgerModelException.forExistingCategory(entry);
 		}
 		category = new ReserveCategory(entry.parent().date(),
-				new DateRange(entry.parent().date(), entry.parent().period()), entry.owner());
+				new DateRange(entry.parent().date(), entry.parent().period()), entry.percentage(), entry.owner());
 		categories.put(entry.name(), category);
 	}
 

--- a/src/main/java/cashpiles/model/ManualGoalCategory.java
+++ b/src/main/java/cashpiles/model/ManualGoalCategory.java
@@ -11,11 +11,6 @@ class ManualGoalCategory extends Category {
 	}
 
 	@Override
-	BudgetPeriod allocate(BudgetPeriod period) {
-		return period;
-	}
-
-	@Override
 	public ManualGoalCategory clone() {
 		return (ManualGoalCategory) super.clone();
 	}

--- a/src/main/java/cashpiles/model/ReserveCategory.java
+++ b/src/main/java/cashpiles/model/ReserveCategory.java
@@ -1,13 +1,19 @@
 package cashpiles.model;
 
+import java.math.BigDecimal;
 import java.time.LocalDate;
 
+import cashpiles.ledger.CategoryTransactionEntry;
 import cashpiles.time.DateRange;
+import cashpiles.util.Lists;
 
 class ReserveCategory extends Category {
 
-	ReserveCategory(LocalDate startDate, DateRange startPeriod, String owner) {
+	private BigDecimal percentage;
+
+	ReserveCategory(LocalDate startDate, DateRange startPeriod, BigDecimal percentage, String owner) {
 		super(startDate, startPeriod, owner);
+		this.percentage = percentage;
 	}
 
 	@Override
@@ -26,6 +32,24 @@ class ReserveCategory extends Category {
 	@Override
 	public String type() {
 		return "Reserve";
+	}
+
+	@Override
+	ReserveCategory withAllocation(Allocation allocation) throws LedgerModelException {
+		var retval = withDate(allocation.entry());
+		if (!allocation.active()) {
+			return retval;
+		}
+		var lastPeriod = Lists.lastOf(retval.periods);
+		retval.periods.remove(retval.periods.size() - 1);
+		retval.periods.add(lastPeriod.withAllocation(
+				lastPeriod.allocation().add(allocation.entry().amount().percentage(retval.percentage))));
+		return retval;
+	}
+
+	@Override
+	ReserveCategory withDate(CategoryTransactionEntry entry) throws LedgerModelException {
+		return (ReserveCategory) super.withDate(entry);
 	}
 
 }


### PR DESCRIPTION
This PR links Reserve categories and Income categories together using an Allocation that can be extended if/when future linkages between category types are required.  It uses the visitor pattern to keep the allocation logic in the Allocation class and its children, rather than putting cross-category allocation logic in the categories themselves.